### PR TITLE
Testing from ionic and grape with travis working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,35 @@
+sudo: required
+
 language: ruby
 
 rvm:
   - 2.3.0
 
 env:
-  - TEST_DIR=grape
+  - API_TEST_DIR=grape
 
-script: cd $TEST_DIR && bundle install && bundle exec rspec spec
+addons:
+  postgresql: "9.5.5"
+apt:
+  sources:
+    - google-chrome
+  packages:
+    - google-chrome-stable
+    - google-chrome-beta
+
+before_install:
+  - nvm install 7.1.0
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+before_script:
+  - sudo apt-get install postgresql-9.3 postgresql-server-dev-9.3 libpq-dev
+  - npm install -g angular-cli
+  - npm install -g karma
+  - cd ionic
+  - npm install && cd ..
+
+script:
+  - cd $API_TEST_DIR && bundle install && bundle exec rspec spec
+  - cd ../ionic && karma start karma.conf.js --single-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ language: ruby
 rvm:
   - 2.3.0
 
-env:
-  - API_DIR=grape
-  - APP_DIR=ionic
-
 addons:
   postgresql: "9.5.5"
 apt:
@@ -32,5 +28,5 @@ before_script:
   - npm install && cd ..
 
 script:
-  - cd $API_DIR && bundle install && bundle exec rspec spec
-  - cd .. && cd ionic && karma start karma.conf.js --single-run
+  - cd grape && bundle install && bundle exec rspec spec
+  - cd ../ionic && karma start karma.conf.js --single-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ rvm:
   - 2.3.0
 
 env:
-  - API_TEST_DIR=grape
+  - API_DIR=grape
+  - APP_DIR=ionic
 
 addons:
   postgresql: "9.5.5"
@@ -31,5 +32,5 @@ before_script:
   - npm install && cd ..
 
 script:
-  - cd $API_TEST_DIR && bundle install && bundle exec rspec spec
-  - cd ../ionic && karma start karma.conf.js --single-run
+  - cd $API_DIR && bundle install && bundle exec rspec spec
+  - cd .. && cd ionic && karma start karma.conf.js --single-run

--- a/grape/Gemfile.lock
+++ b/grape/Gemfile.lock
@@ -45,9 +45,6 @@ GEM
       dm-core (~> 1.2.0)
     dm-migrations (1.2.0)
       dm-core (~> 1.2.0)
-    dm-postgres-adapter (1.2.0)
-      dm-do-adapter (~> 1.2.0)
-      do_postgres (~> 0.10.6)
     dm-serializer (1.2.2)
       dm-core (~> 1.2.0)
       fastercsv (~> 1.5)
@@ -71,8 +68,6 @@ GEM
       uuidtools (~> 2.1)
     dm-validations (1.2.0)
       dm-core (~> 1.2.0)
-    do_postgres (0.10.17)
-      data_objects (= 0.10.17)
     do_sqlite3 (0.10.17)
       data_objects (= 0.10.17)
     equalizer (0.0.11)
@@ -87,7 +82,7 @@ GEM
       rack (>= 1.3.0)
       rack-accept
       virtus (>= 1.0.0)
-    grape-entity (0.4.8)
+    grape-entity (0.5.1)
       activesupport
       multi_json (>= 1.3.2)
     hashie (3.4.6)
@@ -102,7 +97,6 @@ GEM
       tool (~> 0.2)
     mustermann-grape (0.4.0)
       mustermann (= 0.4.0)
-    pg (0.19.0)
     public_suffix (2.0.4)
     rack (2.0.1)
     rack-accept (0.4.5)
@@ -141,15 +135,14 @@ PLATFORMS
 
 DEPENDENCIES
   data_mapper
-  dm-postgres-adapter
   dm-sqlite-adapter
+  dm-timestamps
   grape
   grape-entity
-  pg
   rack-cors
   rack-test
   rspec
   sqlite3
 
 BUNDLED WITH
-   1.13.5
+   1.11.2

--- a/grape/models/task.rb
+++ b/grape/models/task.rb
@@ -1,3 +1,5 @@
+require 'dm-validations'
+
 module Huertask
   class Task
     include DataMapper::Resource
@@ -15,8 +17,11 @@ module Huertask
 
     if nil != @from_date
       validates_with_block @from_date do
-        return true if @from_date > Time.now
-        [false, "from_date must be bigger than now"]
+        if @from_date > Time.now
+          true
+        else
+          [false, "from_date must be bigger than now"]
+        end
       end
     end
 

--- a/grape/spec/routes/tasks_spec.rb
+++ b/grape/spec/routes/tasks_spec.rb
@@ -20,7 +20,7 @@ describe Huertask::API do
     end
 
     it "returns future tasks" do
-      get "api/tasks?category=future"
+      get "api/tasks"
 
       expect(last_response).to be_ok
       expect(past_tasks).to be_empty
@@ -31,7 +31,7 @@ describe Huertask::API do
     end
 
     def past_task? task
-      task["date"] < request_time
+      task["from_date"] < request_time
     end
   end
 end

--- a/grape/spec/task_spec.rb
+++ b/grape/spec/task_spec.rb
@@ -1,44 +1,5 @@
 require_relative '../models/task'
 
-describe Task  do
+describe Huertask::Task  do
 
-  let(:data) {{title: "recoger lechugas", date: Date.new(2016, 10, 10), people_left: 5, category: "Cosecha"}}
-
-  it 'has a title' do
-    task = Task.new(data)
-
-    title = task.title
-
-    expect(title).to eq(data[:title])
-  end
-
-  it 'has a date' do
-    task = Task.new(data)
-
-    date = task.date
-
-    expect(date).to eq(data[:date])
-  end
-
-  it 'has a number of people to fill' do
-    task = Task.new(data)
-
-    people = task.people_left
-
-    expect(people).to eq(data[:people_left])
-  end
-
-  it 'has a category' do
-    task = Task.new(data)
-
-    category = task.category
-
-    expect(category).to eq(data[:category])
-  end
-
-  it 'cannot has a nil member' do
-    data_without_people = {title: "recoger lechugas", date: Date.new(2016, 02, 10)}
-
-    expect {Task.new(data_without_people)}.to raise_error(ArgumentError)
-  end
 end

--- a/grape/spec/task_spec.rb
+++ b/grape/spec/task_spec.rb
@@ -1,5 +1,29 @@
 require_relative '../models/task'
 
 describe Huertask::Task  do
+  it "should validates presence of: title, from_date, people and category" do
+    task = Huertask::Task.new
+    save_result = task.save
 
+    expect(save_result).to be false
+    expect(task.errors.size).to eq 4
+    expect(task.errors[:title]).to eq ["Title must not be blank"]
+    expect(task.errors[:from_date]).to eq ["From date must not be blank"]
+    expect(task.errors[:category]).to eq ["Category must not be blank"]
+    expect(task.errors[:people]).to eq ["People must not be blank"]
+  end
+
+  it "should validates length of: title" do
+    task = Huertask::Task.new({
+      "title":"",
+      "from_date":"2020-01-10T13:00:00+00:00",
+      "people":1,
+      "category":"5"
+    })
+    save_result = task.save
+
+    expect(save_result).to be false
+    expect(task.errors[:title]).to eq ["Title must be between 1 and 100 characters long", "Title must not be blank"]
+  end
 end
+

--- a/ionic/src/pages/create-task/create-task.spec.ts
+++ b/ionic/src/pages/create-task/create-task.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, async } from '@angular/core/testing';
+import { TestUtils }               from '../../test';
+import { CreateTask }             from './create-task';
+
+
+let fixture: ComponentFixture<Tasks> = null;
+let instance: any = null;
+
+describe('Pages: Create Task', () => {
+
+  beforeEach(async(() => TestUtils.beforeEachCompiler([CreateTask]).then(compiled => {
+    fixture = compiled.fixture;
+    instance = compiled.instance;
+  })));
+
+  it('should create the create task page', async(() => {
+    expect(instance).toBeTruthy();
+  }));
+});

--- a/ionic/src/pages/tasks/task.spec.ts
+++ b/ionic/src/pages/tasks/task.spec.ts
@@ -4,6 +4,7 @@ import { Tasks }          from './tasks';
 
 let fixture: ComponentFixture<Tasks> = null;
 let instance: any = null;
+let tabName: string;
 
 describe('Pages: Tasks', () => {
 
@@ -12,7 +13,25 @@ describe('Pages: Tasks', () => {
     instance = compiled.instance;
   })));
 
-  it('should create the hello ionic page', async(() => {
+  it('should create the task page', async(() => {
     expect(instance).toBeTruthy();
+  }));
+
+  it('should has a tasks list', async(() => {
+    expect(instance.list).toBeTruthy();
+  }));
+
+  it('should filter tasks when select a tab', async(() => {
+    tabName = "TASKS.PREVIOUS";
+
+    instance.showTasks(tabName);
+
+    expect(instance.list).toEqual(instance.pastTasks);
+
+    tabName = "TASKS.NEXT";
+
+    instance.showTasks(tabName);
+
+    expect(instance.list).toEqual(instance.tasks);
   }));
 });

--- a/ionic/src/providers/task.service.spec.ts
+++ b/ionic/src/providers/task.service.spec.ts
@@ -1,0 +1,44 @@
+import { async, inject, TestBed } from '@angular/core/testing';
+import { HttpModule } from '@angular/http';
+
+import { TaskService } from './task.service';
+
+describe('TaskService', () => {
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        TaskService
+      ],
+      imports: [
+        HttpModule
+      ]
+    });
+  });
+
+  it('should construct', async(inject([TaskService], (service) => {
+    expect(service).toBeDefined();
+  })));
+
+  it('should get a list of future tasks', async(inject([TaskService], (service) => {
+    service.getFutureTasks().subscribe(tasks => {
+      var pastTasks = tasks.filter(function(e){ return Date.parse(e.from_date) <= Date.now()});
+      expect(pastTasks.length).toEqual(0);
+    });
+  })));
+
+  it('should get a list of past tasks', async(inject([TaskService], (service) => {
+    service.getPastTasks().subscribe(tasks => {
+      var futureTasks = tasks.filter(function(e){ return Date.parse(e.from_date) > Date.now()});
+      expect(futureTasks.length).toEqual(0);
+    });
+  })));
+
+  it('should create a new task', async(inject([TaskService], (service) => {
+    var newTask = {title: 'Tarea creada por test', from_date: '2020-01-10T13:00:00+00:00', people: 1, category: '5'};
+    service.createTask(newTask).subscribe(task => {
+      expect(task.id).not.toBe(null);
+    });
+  })));
+
+});

--- a/ionic/src/test.ts
+++ b/ionic/src/test.ts
@@ -9,8 +9,11 @@ import 'zone.js/dist/fake-async-test';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TestBed } from '@angular/core/testing';
-import { App, MenuController, NavController, Platform, Config, Keyboard, Form, IonicModule }  from 'ionic-angular';
+import { App, MenuController, NavController, Platform, Config, Keyboard, Form, IonicModule, ToastController, GestureController }  from 'ionic-angular';
 import { ConfigMock, NavMock, PlatformMock } from './mocks';
+import { TranslateModule } from 'ng2-translate';
+import { TaskService } from './providers/task.service';
+
 
 // Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
 declare var __karma__: any;
@@ -63,11 +66,15 @@ export class TestUtils {
         {provide: MenuController, useClass: ConfigMock},
         {provide: NavController, useClass: NavMock},
         {provide: Platform, useClass: PlatformMock},
+        TaskService,
+        ToastController,
+        GestureController
       ],
       imports: [
         FormsModule,
         IonicModule,
         ReactiveFormsModule,
+        TranslateModule.forRoot(),
       ],
     });
   }


### PR DESCRIPTION
Modificado el travis.yml para que pueda correr los test de angular y de ruby.

Creados los test que faltaban del servicio y las paginas de ionic y tambien los del modelo de datamapper en grape