### PR TITLE
People left msg

### DIFF
--- a/app/src/pages/task-detail/task-detail.html
+++ b/app/src/pages/task-detail/task-detail.html
@@ -49,9 +49,7 @@
       <ion-col>{{task.note}}</ion-col>
     </ion-row>
     <ion-row class="remaining people">
-      <ion-col>
-        {{ 'TASK.PEOPLE_LEFT.LABEL' | translate }}:
-        <span>{{ task.required_people - task.people_going.length}}</span>
+      <ion-col [innerHTML]='peopleMessage(task) | translate:{count: peopleLeft(task)}'>
       </ion-col>
     </ion-row>
     <ion-row class="people_going">

--- a/app/src/pages/task-detail/task-detail.ts
+++ b/app/src/pages/task-detail/task-detail.ts
@@ -25,6 +25,23 @@ export class TaskDetail {
     }
   }
 
+  peopleLeft(task){
+    let people_left = task.required_people - task.people_going.length;
+    if (people_left < 0){ people_left = 0; }
+    return people_left
+  }
+
+  peopleMessage(task){
+    switch (this.peopleLeft(task)) {
+       case 0:
+         return "TASK.PEOPLE_LEFT.MSG.ZERO";
+       case 1:
+         return "TASK.PEOPLE_LEFT.MSG.ONE";
+       default:
+         return "TASK.PEOPLE_LEFT.MSG.PLURAL";
+    }
+  }
+
   getCategoryName(id){
     return this.taskService.getCategory(id).name;
   }

--- a/app/src/pages/tasks/tasks.html
+++ b/app/src/pages/tasks/tasks.html
@@ -31,7 +31,7 @@
       <ion-grid>
         <ion-row>
           <ion-col class="from-date">{{ fromDateMessage(task) }}</ion-col>
-          <ion-col [innerHTML]='peopleMessage(task) | translate:{count: task.required_people}'></ion-col>
+          <ion-col [innerHTML]='peopleMessage(task) | translate:{count: peopleLeft(task)}'></ion-col>
         </ion-row>
       </ion-grid>
     </ion-card-content>

--- a/app/src/pages/tasks/tasks.ts
+++ b/app/src/pages/tasks/tasks.ts
@@ -31,8 +31,14 @@ export class Tasks {
     });
 	}
 
+  peopleLeft(task){
+    let people_left = task.required_people - task.people_going.length;
+    if (people_left < 0){ people_left = 0; }
+    return people_left
+  }
+
   peopleMessage(task){
-    switch (task.required_people) {
+    switch (this.peopleLeft(task)) {
        case 0:
          return "TASK.PEOPLE_LEFT.MSG.ZERO";
        case 1:


### PR DESCRIPTION
Añadido el mensaje de personas restantes en la página de detalle.
Corregido el mismo mensaje en el listado (mostraba los requeridos sin restar los apuntados)

Implica código duplicado en ambos controladores. Pide refactorización. Podemos sacarlo al servicio, aunque creo que lo ideal sería trabajar con el modelo. 