### PR TITLE
fix duplicate-task page title

### DIFF
--- a/app/src/pages/duplicate-task/duplicate-task.html
+++ b/app/src/pages/duplicate-task/duplicate-task.html
@@ -1,6 +1,6 @@
 <ion-header>
   <ion-navbar>
-    <ion-title>DuplicateTask</ion-title>
+    <ion-title>{{ 'TASK.CREATE.TITLE' | translate }}</ion-title>
   </ion-navbar>
 </ion-header>
 


### PR DESCRIPTION
Entiendo que no tiene sentido poner un título diferente al de la página de creación.